### PR TITLE
Add support for IAM roles

### DIFF
--- a/ec2-consistent-snapshot
+++ b/ec2-consistent-snapshot
@@ -8,6 +8,8 @@ use warnings;
 use Getopt::Long;
 use Pod::Usage;
 use File::Slurp;
+use LWP::Simple;
+use JSON;
 use Time::HiRes qw(ualarm usleep);
 use Net::Amazon::EC2 0.11;
 use POSIX ':signal_h';
@@ -57,6 +59,7 @@ GetOptions(
   'aws-access-key-id-file=s'     => \$aws_access_key_id_file,
   'aws-secret-access-key-file=s' => \$aws_secret_access_key_file,
   'aws-credentials-file=s'       => \$aws_credentials_file,
+  'aws-iam-role'                 => \$aws_iam_role,
   'region=s'                     => \$region,
   'ec2-endpoint=s'               => \$ec2_endpoint,
   'description=s'                => \@descriptions,
@@ -118,7 +121,7 @@ if ( scalar (@descriptions) == 1 ) {
   for ( my $index = 1; $index < scalar (@volume_ids); ++$index ) {
     $descriptions[$index] = $descriptions[0];
   }
-} 
+}
 
 my $mysql_stopped = undef;
 my $mysql_dbh = undef;
@@ -479,7 +482,18 @@ sub determine_access_keys {
     return ($aws_access_key_id, $aws_secret_access_key);
   }
 
-  # 3. $AWS_CREDENTIALS or $HOME/.awssecret
+  #3 --aws-iam-role
+  if ($aws_iam_role) {
+    $META_DATA_URL = "http://169.254.169.254";
+    $RESOURCE = "latest/meta-data/iam/security-credentials";
+    $role = get("$META_DATA_URL/$RESOURCE");
+    $creds = decode_json(get("$META_DATA_URL/$RESOURCE/$role"));
+    $aws_access_key_id = $creds->{'AccessKeyId'};
+    $aws_secret_access_key = $creds->{'SecretAccessKey'};
+    return ($aws_access_key_id, $aws_secret_access_key);
+  }
+
+  # 4. $AWS_CREDENTIALS or $HOME/.awssecret
   return read_awssecret($aws_credentials_file);
 }
 
@@ -561,6 +575,12 @@ File containing both the Amazon AWS access key and secret access
 key on seprate lines and in that order.  Defaults to contents of
 $AWS_CREDENTIALS environment variable or the value $HOME/.awssecret
 
+=item  --aws-iam-role
+
+This AWS instance has been setup to IAM roles with the correct
+permissions (ec2:CreateSnapshot). The script will get the Access
+Key and Secret Key from its metadata.
+
 =item --region REGION
 
 Specify a different EC2 region like "eu-west-1".  Defaults to
@@ -587,7 +607,7 @@ works on any filesystems that support freezing, provided the kernel
 you are using supports it. (Linux Ext3/4, ReiserFS, JFS, XFS.)
 fsfreeze comes with newer versions of util-linux.
 
-You may specify this option multiple times if you need to freeze multiple 
+You may specify this option multiple times if you need to freeze multiple
 filesystems on the the EBS volume(s).
 
 =item --mysql
@@ -597,8 +617,8 @@ database, which will be flushed and locked during the snapshot.
 
 =item --mysql-defaults-file FILE
 
-MySQL defaults file, containing host, username and password, this 
-option will ignore the --mysql-host, --mysql-username, 
+MySQL defaults file, containing host, username and password, this
+option will ignore the --mysql-host, --mysql-username,
 --mysql-password parameters
 
 =item --mysql-host HOST
@@ -661,7 +681,7 @@ start/unlock.
 =head1 ARGUMENTS
 
 =over
-    
+
 =item VOLUMEID
 
 EBS volume id(s) for which a snapshot is to be created.


### PR DESCRIPTION
IAM roles make available additional instance metadata which includes a
temporary access_key, secret_key, and token. These rotate every few
minutes and can be used for API requests. This change allievates the
need to store keys locally and manage those keys across hosts.

---

My perl is rusty if there is some other way to achieve this in a better/lighter
fashion I'm happy to rework it.
