### PR TITLE
IAM Role authentication

### DIFF
--- a/ec2-consistent-snapshot
+++ b/ec2-consistent-snapshot
@@ -32,6 +32,7 @@ my $aws_secret_access_key      = $ENV{AWS_SECRET_ACCESS_KEY};
 my $aws_access_key_id_file     = $ENV{AWS_ACCESS_KEY_ID};
 my $aws_secret_access_key_file = $ENV{AWS_SECRET_ACCESS_KEY};
 my $aws_credentials_file       = $ENV{AWS_CREDENTIALS};
+my $aws_iam_role               = 0;
 my $region                     = undef;
 my $ec2_endpoint               = undef;
 my @descriptions               = ();
@@ -115,10 +116,11 @@ $freeze_cmd    = "xfs_freeze"
 
 #---- MAIN ----
 
-($aws_access_key_id,      $aws_secret_access_key) = determine_access_keys(
+($aws_access_key_id,      $aws_secret_access_key, 
+                          $aws_iam_role)          = determine_access_keys(
  $aws_access_key_id,      $aws_secret_access_key,
  $aws_access_key_id_file, $aws_secret_access_key_file,
- $aws_credentials_file,
+ $aws_credentials_file,   $aws_iam_role,
 );
 die "$Prog: ERROR: Can't find AWS access key or secret access key"
   unless $aws_access_key_id and $aws_secret_access_key;
@@ -230,6 +232,7 @@ sub ebs_snapshot {
   my $ec2 = Net::Amazon::EC2->new(
     AWSAccessKeyId  => $aws_access_key_id,
     SecretAccessKey => $aws_secret_access_key,
+    ($aws_iam_role ? (SecurityToken => $aws_iam_role) : ()),
     ($ec2_endpoint ? (base_url => $ec2_endpoint) : ()),
     # ($Debug ? (debug => 1) : ()),
   );
@@ -603,7 +606,7 @@ sub read_mycnf {
 sub determine_access_keys {
   my ($aws_access_key_id,      $aws_secret_access_key,
       $aws_access_key_id_file, $aws_secret_access_key_file,
-      $aws_credentials_file,
+      $aws_credentials_file,   $aws_iam_role,
      ) = @_;
 
   # 1. --aws-access-key-id and --aws-secret-access-key
@@ -623,13 +626,14 @@ sub determine_access_keys {
 
   #3 --aws-iam-role
   if ($aws_iam_role) {
-    $META_DATA_URL = "http://169.254.169.254";
-    $RESOURCE = "latest/meta-data/iam/security-credentials";
-    $role = get("$META_DATA_URL/$RESOURCE");
-    $creds = decode_json(get("$META_DATA_URL/$RESOURCE/$role"));
-    $aws_access_key_id = $creds->{'AccessKeyId'};
+    my $META_DATA_URL = "http://169.254.169.254";
+    my $RESOURCE = "latest/meta-data/iam/security-credentials";
+    my $role = get("$META_DATA_URL/$RESOURCE");
+    my $creds = decode_json(get("$META_DATA_URL/$RESOURCE/$role"));
+    $aws_access_key_id     = $creds->{'AccessKeyId'};
     $aws_secret_access_key = $creds->{'SecretAccessKey'};
-    return ($aws_access_key_id, $aws_secret_access_key);
+    $aws_iam_role          = $creds->{'Token'};
+    return ($aws_access_key_id, $aws_secret_access_key, $aws_iam_role);
   }
 
   # 4. $AWS_CREDENTIALS or $HOME/.awssecret


### PR DESCRIPTION
Implementation of IAM Role Authentication using a modified version of Net::Amazon::EC2. Changes from metcalfc adding the right token use.

The patch needed in Net::Amazon::EC2 is already submitted to CPAN in https://rt.cpan.org/Public/Bug/Display.html?id=81664.
