### PR TITLE
Adding recording of both master and slave binlog positions when possible

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -93,9 +93,16 @@ OPTIONS
         $HOME/.my.cnf file contents.
 
     --mysql-master-status-file FILE
-        Store the MASTER STATUS output in a file on the snapshot. It will be
-        removed after the EBS snapshot is taken. This option will be ignored
-        with --mysql-stop
+        Store the MASTER STATUS (or slave status if this server is a slave) 
+        output in a file on the snapshot. It will be removed after the EBS 
+        snapshot is taken. This option will be ignored with --mysql-stop
+
+    --mysql-status-file FILE
+        Store the MASTER and SLAVE STATUS output in a file on the snapshot. It 
+	will be removed after the EBS snapshot is taken. This option will be 
+	ignored with --mysql-stop. This options is a more flexible alternative
+        to --mysql-master-status-file
+
 
     --mysql-stop
         Indicates that the volume contains data files for a running MySQL

--- a/ec2-consistent-snapshot
+++ b/ec2-consistent-snapshot
@@ -200,6 +200,15 @@ END {
     }
   }
 
+  if ( defined($mysql_status_file) ) {
+    $Debug and warn "$Prog: ", scalar localtime,
+      ": removing mysql status file: $mysql_status_file\n";
+    if ( not $Noaction ) {
+      unlink $mysql_status_file
+        or die "$Prog: Couldn't remove file: $mysql_status_file: $!\n";
+    }
+  }
+
   if ( $mongo_stopped ) {
     mongo_start();
   } elsif ( $mongo_dbh ) {

--- a/ec2-consistent-snapshot
+++ b/ec2-consistent-snapshot
@@ -15,6 +15,7 @@ use Net::Amazon::EC2 0.11;
 use POSIX ':signal_h';
 use DateTime::Locale;
 use DateTime::TimeZone;
+use Sys::Hostname;
 
 my $SIGALRM = 14;
 
@@ -432,22 +433,29 @@ sub mysql_lock {
   );
 
   my ($mysql_logfile, $mysql_position,
-      $mysql_binlog_do_db, $mysql_binlog_ignore_db);
+      $mysql_master, $mysql_binlog_do_db, $mysql_binlog_ignore_db);
+  my ($mysql_slave_logfile, $mysql_slave_position,
+      $mysql_slave_master, $mysql_slave_binlog_do_db, $mysql_slave_binlog_ignore_db);
   if ( not $Noaction ) {
     # This might be a slave database already
     my $slave_status = $mysql_dbh->selectrow_hashref(q{ SHOW SLAVE STATUS });
-    $mysql_logfile           = $slave_status->{Slave_IO_State}
+    $mysql_slave_logfile     = $slave_status->{Slave_IO_State}
                              ? $slave_status->{Master_Log_File}
                              : undef;
-    $mysql_position          = $slave_status->{Read_Master_Log_Pos};
-    $mysql_binlog_do_db      = $slave_status->{Replicate_Do_DB};
-    $mysql_binlog_ignore_db  = $slave_status->{Replicate_Ignore_DB};
+    $mysql_slave_position    = $slave_status->{Slave_IO_State}
+                             ? $slave_status->{Read_Master_Log_Pos}
+			     : undef;
+    $mysql_slave_master	     = $slave_status->{Slave_IO_State}
+                             ? $slave_status->{Master_Host}
+                             : undef;
+    $mysql_slave_binlog_do_db      = $slave_status->{Replicate_Do_DB};
+    $mysql_slave_binlog_ignore_db  = $slave_status->{Replicate_Ignore_DB};
 
     # or this might be the master
+    $mysql_master = hostname;
     ($mysql_logfile, $mysql_position,
      $mysql_binlog_do_db, $mysql_binlog_ignore_db) =
-      $mysql_dbh->selectrow_array(q{  SHOW MASTER STATUS  })
-      unless $mysql_logfile;
+      $mysql_dbh->selectrow_array(q{  SHOW MASTER STATUS  });
   }
 
   $mysql_dbh->do(q{ SET SQL_LOG_BIN=1 }) unless $Noaction;
@@ -463,10 +471,16 @@ sub mysql_lock {
       open(MYSQLMASTERSTATUS,"> $mysql_master_status_file") or
         die "$Prog: Unable to open for write: $mysql_master_status_file: $!\n";
       print MYSQLMASTERSTATUS <<"EOM";
+master_host="$mysql_master"
 master_log_file="$mysql_logfile"
 master_log_pos="$mysql_position"
 master_binlog_do_db="$mysql_binlog_do_db"
 master_binlog_ignore_db="$mysql_binlog_ignore_db"
+slave_master_host="$mysql_slave_master"
+slave_log_file="$mysql_slave_logfile"
+slave_log_pos="$mysql_slave_position"
+slave_binlog_do_db="$mysql_slave_binlog_do_db"
+slave_binlog_ignore_db="$mysql_slave_binlog_ignore_db"
 EOM
       close(MYSQLMASTERSTATUS);
     }

--- a/ec2-consistent-snapshot
+++ b/ec2-consistent-snapshot
@@ -45,6 +45,7 @@ my $mysql                      = 0;
 #my $mysql_defaults_file        = "$ENV{HOME}/.my.cnf";
 my $mysql_defaults_file        = undef;
 my $mysql_socket               = undef;
+my $mysql_status_file          = undef;
 my $mysql_master_status_file   = undef;
 my $mysql_username             = undef;
 my $mysql_password             = undef;
@@ -85,6 +86,7 @@ GetOptions(
   'mysql-defaults-file=s'        => \$mysql_defaults_file,
   'mysql-socket=s'               => \$mysql_socket,
   'mysql-master-status-file=s'   => \$mysql_master_status_file,
+  'mysql-status-file=s'          => \$mysql_status_file,
   'mysql-username=s'             => \$mysql_username,
   'mysql-password=s'             => \$mysql_password,
   'mysql-host=s'                 => \$mysql_host,
@@ -437,21 +439,17 @@ sub mysql_lock {
   my ($mysql_slave_logfile, $mysql_slave_position,
       $mysql_slave_master, $mysql_slave_binlog_do_db, $mysql_slave_binlog_ignore_db);
   if ( not $Noaction ) {
-    # This might be a slave database already
+    # Get slave database info 
     my $slave_status = $mysql_dbh->selectrow_hashref(q{ SHOW SLAVE STATUS });
-    $mysql_slave_logfile     = $slave_status->{Slave_IO_State}
-                             ? $slave_status->{Master_Log_File}
-                             : undef;
-    $mysql_slave_position    = $slave_status->{Slave_IO_State}
-                             ? $slave_status->{Read_Master_Log_Pos}
-			     : undef;
-    $mysql_slave_master	     = $slave_status->{Slave_IO_State}
-                             ? $slave_status->{Master_Host}
-                             : undef;
-    $mysql_slave_binlog_do_db      = $slave_status->{Replicate_Do_DB};
-    $mysql_slave_binlog_ignore_db  = $slave_status->{Replicate_Ignore_DB};
+    if ($slave_status->{Slave_IO_State}){
+      $mysql_slave_logfile           = $slave_status->{Master_Log_File};
+      $mysql_slave_position          = $slave_status->{Read_Master_Log_Pos};
+      $mysql_slave_master            = $slave_status->{Master_Host};
+      $mysql_slave_binlog_do_db      = $slave_status->{Replicate_Do_DB};
+      $mysql_slave_binlog_ignore_db  = $slave_status->{Replicate_Ignore_DB};
+    }
 
-    # or this might be the master
+    # Get Master Position Info
     $mysql_master = hostname;
     ($mysql_logfile, $mysql_position,
      $mysql_binlog_do_db, $mysql_binlog_ignore_db) =
@@ -460,17 +458,19 @@ sub mysql_lock {
 
   $mysql_dbh->do(q{ SET SQL_LOG_BIN=1 }) unless $Noaction;
 
-  print "$Prog: master_log_file=\"$mysql_logfile\",",
-              " master_log_pos=$mysql_position\n"
-    if $mysql_logfile and not $Quiet;
+  print "$Prog: master_log_file=\"",
+    ($mysql_slave_logfile?$mysql_slave_logfile:$mysql_logfile),
+    ",\", master_log_pos=",
+    ($mysql_slave_position?$mysql_slave_position:$mysql_position),
+    "\n" if $mysql_logfile and not $Quiet;
 
-  if ( defined($mysql_master_status_file) && $mysql_logfile ) {
+  if ( defined($mysql_status_file) && $mysql_logfile ) {
     $Debug and warn "$Prog: ", scalar localtime,
-      ": writing MASTER STATUS to $mysql_master_status_file\n";
+      ": writing MYSQL STATUS to $mysql_status_file\n";
     if ( not $Noaction ) {
-      open(MYSQLMASTERSTATUS,"> $mysql_master_status_file") or
-        die "$Prog: Unable to open for write: $mysql_master_status_file: $!\n";
-      print MYSQLMASTERSTATUS <<"EOM";
+      open(MYSQLSTATUS,"> $mysql_status_file") or
+        die "$Prog: Unable to open for write: $mysql_status_file: $!\n";
+      print MYSQLSTATUS <<"EOM";
 master_host="$mysql_master"
 master_log_file="$mysql_logfile"
 master_log_pos="$mysql_position"
@@ -482,6 +482,31 @@ slave_log_pos="$mysql_slave_position"
 slave_binlog_do_db="$mysql_slave_binlog_do_db"
 slave_binlog_ignore_db="$mysql_slave_binlog_ignore_db"
 EOM
+      close(MYSQLSTATUS);
+    }
+  }
+
+  if ( defined($mysql_master_status_file) && $mysql_logfile ) {
+    $Debug and warn "$Prog: ", scalar localtime,
+      ": writing MASTER STATUS to $mysql_master_status_file\n";
+    if ( not $Noaction ) {
+      open(MYSQLMASTERSTATUS,"> $mysql_master_status_file") or
+        die "$Prog: Unable to open for write: $mysql_master_status_file: $!\n";
+      if ( $mysql_slave_logfile) {
+        print MYSQLMASTERSTATUS <<"EOM";
+master_log_file="$mysql_slave_logfile"
+master_log_pos="$mysql_slave_position"
+master_binlog_do_db="$mysql_slave_binlog_do_db"
+master_binlog_ignore_db="$mysql_slave_binlog_ignore_db"
+EOM
+      }else{
+        print MYSQLMASTERSTATUS <<"EOM";
+master_log_file="$mysql_logfile"
+master_log_pos="$mysql_position"
+master_binlog_do_db="$mysql_binlog_do_db"
+master_binlog_ignore_db="$mysql_binlog_ignore_db"
+EOM
+      }
       close(MYSQLMASTERSTATUS);
     }
   }


### PR DESCRIPTION
When taking a backup from a mysql slave server there may be some confusion as to which binlog position to record. If we intend to create a slave of this slave's master, we will want to use the slave position, but if we intend to create a slave of this slave - we will want to record the master position and ignore the slave position. What is worse, we may not know what we intend to use this snapshot for until later. So, to make this simple and flexible we can record BOTH master and slave position into (now slightly misnamed) master status file - allowing us to use either set of positions at restore time. To aid in automation of the new slave deployment,  I also added recording of the hostnames the positions refer to.

NOTE: This has potential to confuse existing automation as the master_log_file/pos parameters in master status file will now always refer to master position.