### PR TITLE
Mysql: add option for using "STOP SLAVE"

### DIFF
--- a/ec2-consistent-snapshot
+++ b/ec2-consistent-snapshot
@@ -408,6 +408,12 @@ sub mysql_connect {
   return $mysql_dbh;
 }
 
+sub mysql_is_slave {
+  my ($mysql_dbh) = @_;
+  my $slave_status = $mysql_dbh->selectrow_hashref(q{ SHOW SLAVE STATUS });
+  return $slave_status->{Slave_SQL_Running} eq 'Yes';
+}
+
 sub mysql_lock {
   my ($mysql_dbh) = @_;
 
@@ -419,12 +425,12 @@ sub mysql_lock {
     # STOP SLAVE blocks until the current replication group is done processing
     # so we only really need to run it once with a high timeout
     sql_timeout_retry(
-      q{ STOP SLAVE},
-      "MySQL flush",
+      q{ STOP SLAVE },
+      "MySQL Stop Replication",
       $lock_timeout * $lock_tries,
       1,
       0,
-    );
+    ) unless $Noaction;
   } else {
     # Try a flush first without locking so the later flush with lock
     # goes faster.  This may not be needed as it seems to interfere with
@@ -452,9 +458,7 @@ sub mysql_lock {
   if ( not $Noaction ) {
     # This might be a slave database already
     my $slave_status = $mysql_dbh->selectrow_hashref(q{ SHOW SLAVE STATUS });
-    $mysql_logfile           = $slave_status->{Slave_IO_State}
-                             ? $slave_status->{Master_Log_File}
-                             : undef;
+    $mysql_logfile           = $slave_status->{Master_Log_File};
     $mysql_position          = $slave_status->{Read_Master_Log_Pos};
     $mysql_binlog_do_db      = $slave_status->{Replicate_Do_DB};
     $mysql_binlog_ignore_db  = $slave_status->{Replicate_Ignore_DB};
@@ -463,7 +467,7 @@ sub mysql_lock {
     ($mysql_logfile, $mysql_position,
      $mysql_binlog_do_db, $mysql_binlog_ignore_db) =
       $mysql_dbh->selectrow_array(q{  SHOW MASTER STATUS  })
-      unless $mysql_logfile;
+      unless mysql_is_slave($mysql_dbh);
   }
 
   $mysql_dbh->do(q{ SET SQL_LOG_BIN=1 }) unless $Noaction;

--- a/ec2-consistent-snapshot
+++ b/ec2-consistent-snapshot
@@ -42,6 +42,7 @@ my $mongo_host                 = undef;
 my $mongo_port                 = 27017;
 my $mongo_stop                 = 0;
 my $mysql                      = 0;
+my $mysql_stop_slave           = 0;
 #my $mysql_defaults_file        = "$ENV{HOME}/.my.cnf";
 my $mysql_defaults_file        = undef;
 my $mysql_socket               = undef;
@@ -83,6 +84,7 @@ GetOptions(
   'mongo-port=s'                 => \$mongo_port,
   'mongo-stop'                   => \$mongo_stop,
   'mysql'                        => \$mysql,
+  'mysql-stop-slave'             => \$mysql_stop_slave,
   'mysql-defaults-file=s'        => \$mysql_defaults_file,
   'mysql-socket=s'               => \$mysql_socket,
   'mysql-master-status-file=s'   => \$mysql_master_status_file,
@@ -413,25 +415,37 @@ sub mysql_lock {
   # as this can interfere with long-running queries on the slaves.
   $mysql_dbh->do(q{ SET SQL_LOG_BIN=0 }) unless $Noaction;
 
-  # Try a flush first without locking so the later flush with lock
-  # goes faster.  This may not be needed as it seems to interfere with
-  # some statements anyway.
-  sql_timeout_retry(
-    q{ FLUSH LOCAL TABLES },
-    "MySQL flush",
-    $lock_timeout,
-    $lock_tries,
-    $lock_sleep,
-  );
+  if ( $mysql_stop_slave ) {
+    # STOP SLAVE blocks until the current replication group is done processing
+    # so we only really need to run it once with a high timeout
+    sql_timeout_retry(
+      q{ STOP SLAVE},
+      "MySQL flush",
+      $lock_timeout * $lock_tries,
+      1,
+      0,
+    );
+  } else {
+    # Try a flush first without locking so the later flush with lock
+    # goes faster.  This may not be needed as it seems to interfere with
+    # some statements anyway.
+    sql_timeout_retry(
+      q{ FLUSH LOCAL TABLES },
+      "MySQL flush",
+      $lock_timeout,
+      $lock_tries,
+      $lock_sleep,
+    );
 
-  # Get a lock on the entire database
-  sql_timeout_retry(
-    q{ FLUSH LOCAL TABLES WITH READ LOCK },
-    "MySQL flush & lock",
-    $lock_timeout,
-    $lock_tries,
-    $lock_sleep,
-  );
+    # Get a lock on the entire database
+    sql_timeout_retry(
+      q{ FLUSH LOCAL TABLES WITH READ LOCK },
+      "MySQL flush & lock",
+      $lock_timeout,
+      $lock_tries,
+      $lock_sleep,
+    );
+  }
 
   my ($mysql_logfile, $mysql_position,
       $mysql_binlog_do_db, $mysql_binlog_ignore_db);
@@ -481,7 +495,11 @@ sub mysql_unlock {
   my ($mysql_dbh) = @_;
 
   $Debug and warn "$Prog: ", scalar localtime, ": MySQL unlock\n";
-  $mysql_dbh->do(q{ UNLOCK TABLES }) unless $Noaction;
+  if ( $mysql_stop_slave ) {
+     $mysql_dbh->do(q{ START SLAVE }) unless $Noaction;
+  } else {
+     $mysql_dbh->do(q{ UNLOCK TABLES }) unless $Noaction;
+  }
 
 }
 
@@ -774,6 +792,14 @@ and restarted afterwards. [EXPERIMENTAL]
 
 Indicates that the volume contains data files for a running MySQL
 database, which will be flushed and locked during the snapshot.
+
+=item --mysql-stop-slave
+
+Indicates that "STOP SLAVE" should be used instead of "FLUSH TABLES
+WITH READ LOCK" which can inadvertently lock up mysql, See :
+http://www.mysqlperformanceblog.com/2012/03/23/how-flush-tables-with-read-lock-works-with-innodb-tables/
+Note: This should only be used on mysql replication slaves as this
+doesn't prevent writes by other users during the backup.
 
 =item --mysql-defaults-file FILE
 

--- a/ec2-consistent-snapshot
+++ b/ec2-consistent-snapshot
@@ -458,8 +458,8 @@ sub mysql_lock {
   if ( not $Noaction ) {
     # This might be a slave database already
     my $slave_status = $mysql_dbh->selectrow_hashref(q{ SHOW SLAVE STATUS });
-    $mysql_logfile           = $slave_status->{Master_Log_File};
-    $mysql_position          = $slave_status->{Read_Master_Log_Pos};
+    $mysql_logfile           = $slave_status->{Relay_Master_Log_File};
+    $mysql_position          = $slave_status->{Exec_Master_Log_Pos};
     $mysql_binlog_do_db      = $slave_status->{Replicate_Do_DB};
     $mysql_binlog_ignore_db  = $slave_status->{Replicate_Ignore_DB};
 


### PR DESCRIPTION
MySQL: add option to use "STOP SLAVE"
Instead of "FLUSH TABLES WITH READ LOCK"

MySQL has an issue with read locks and it's very easy to effectively
lock up your whole DB with a SELECT. If a mysql slave is being
snapshotted, "STOP SLAVE" is enough to ensure no more writes happen and
is guaranteed not to lock the DB. Also, "STOP SLAVE" blocks until the
current replication query or query-set is finished, which is nice.

See: http://www.mysqlperformanceblog.com/2012/03/23/how-flush-tables-with-read-lock-works-with-innodb-tables/