### PR TITLE
Added 'dry run' to --noaction option

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ ec2-consistent-snapshot - Create EBS snapshots on EC2 w/consistent filesystem/db
 
 - \-n --noaction
 
-    Don't do it. Just say what you would have done.
+    Dry run. Just say what you would have done, don't do it. 
 
 - \--aws-access-key-id KEY
 - \--aws-secret-access-key SECRET


### PR DESCRIPTION
Dry run is a well known cmd line option. -n does the same and having the 'dry run' phrase in the documentation would help in quicker understanding.
