### PR TITLE
Fix for missing MongoDB::Code module

### DIFF
--- a/ec2-consistent-snapshot
+++ b/ec2-consistent-snapshot
@@ -318,6 +318,7 @@ sub mongo_connect {
   my ($mongo_host, $mongo_port, $mongo_username, $mongo_password) = @_;
 
   require MongoDB;
+  require MongoDB::Code;
   MongoDB->import;
   require MongoDB::Database;
   MongoDB::Database->import;


### PR DESCRIPTION
Most likely a MongoDB (v0.704.0.0) driver bug:

```text
Can't locate object method "new" via package "MongoDB::Code" (perhaps you forgot to load "MongoDB::Code"?) at /usr/local/lib/perl/5.18.2/MongoDB/Collection.pm line 183
```

Requiring the module fix the problem