### PR TITLE
New option - MySQL STOP SLAVE IO_THREAD

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,12 @@ ec2-consistent-snapshot - Create EBS snapshots on EC2 w/consistent filesystem/db
     database.  The database is shutdown before the snapshot is initiated
     and restarted afterwards. \[EXPERIMENTAL\]
 
+- \--mysql-stop-slave-io
+
+    Issue a "STOP SLAVE IO_THREAD" before taking snapshot to stop disk
+    activity. Will also cause MySQL to flush RELAY logs for better consistency.
+    \[EXPERIMENTAL\]
+
 - \--snapshot-timeout SECONDS
 
     How many seconds to wait for the snapshot-create to return.  Defaults

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ ec2-consistent-snapshot - Create EBS snapshots on EC2 w/consistent filesystem/db
 
 - \--mysql-master-status-file FILE
 
-    Store the MASTER STATUS (or slave status if this server is a slave) 
+    Store both the MASTER STATUS (or slave status if this server is a slave) 
     output in a file on the snapshot. It will be removed after the EBS 
     snapshot is taken. This option will be ignored with --mysql-stop
     \[DEPRECATED in favor of mysql-status-file\] 
@@ -125,9 +125,9 @@ ec2-consistent-snapshot - Create EBS snapshots on EC2 w/consistent filesystem/db
 
 - \--mysql-status-file FILE
    
-    Store the MASTER and SLAVE STATUS output in a file on the snapshot. It 
-    will be removed after the EBS snapshot is taken. This option will be 
-    ignored with --mysql-stop. This options is a more flexible alternative
+    Store both MASTER STATUS and SLAVE STATUS output in a file on the snapshot. 
+    It will be removed after the EBS snapshot is taken. This option will be 
+    ignored with --mysql-stop. This options is a more consistent alternative
     to --mysql-master-status-file
          
 

--- a/ec2-consistent-snapshot
+++ b/ec2-consistent-snapshot
@@ -52,6 +52,7 @@ my $mysql_username             = undef;
 my $mysql_password             = undef;
 my $mysql_host                 = undef;
 my $mysql_stop                 = 0;
+my $mysql_stop_slave_io        = 0;
 my $snapshot_timeout           = 10.0; # seconds
 my $lock_timeout               =  0.5; # seconds
 my $lock_tries                 = 60;
@@ -94,6 +95,7 @@ GetOptions(
   'mysql-password=s'             => \$mysql_password,
   'mysql-host=s'                 => \$mysql_host,
   'mysql-stop'                   => \$mysql_stop,
+  'mysql-stop-slave-io'          => \$mysql_stop_slave_io,
   'snapshot-timeout=s'           => \$snapshot_timeout,
   'lock-timeout=s'               => \$lock_timeout,
   'lock-tries=s'                 => \$lock_tries,
@@ -476,6 +478,18 @@ sub mysql_lock {
   # as this can interfere with long-running queries on the slaves.
   $mysql_dbh->do(q{ SET SQL_LOG_BIN=0 }) unless $Noaction;
 
+  # Stopping slave IO thread should prevent disk activity
+  # while taking snapshot
+  if ( $mysql_stop_slave_io ) {
+    sql_timeout_retry(
+      q{ STOP SLAVE IO_THREAD },
+      "MySQL stop slave io_thread",
+      $lock_timeout * $lock_tries, # Try only once, with high timeout
+      1,
+      0,
+    );
+  }
+
   # Try a flush first without locking so the later flush with lock
   # goes faster.  This may not be needed as it seems to interfere with
   # some statements anyway.
@@ -496,17 +510,32 @@ sub mysql_lock {
     $lock_sleep,
   );
 
+  # Make sure we have consistent relay logs before taking snapshot
+  if ( $mysql_stop_slave_io ) {
+    sql_timeout_retry(
+      q{ FLUSH LOCAL RELAY LOGS },
+      "MySQL flush relay logs",
+      $lock_timeout * $lock_tries, # Try only once, with high timeout
+      1,
+      0,
+    );
+  }
+
   my ($mysql_logfile, $mysql_position,
       $mysql_master, $mysql_binlog_do_db, $mysql_binlog_ignore_db);
-  my ($mysql_slave_logfile, $mysql_slave_position,
-      $mysql_slave_master, $mysql_slave_binlog_do_db, $mysql_slave_binlog_ignore_db);
+  my ($mysql_slave_read_logfile, $mysql_slave_read_position,
+      $mysql_slave_exec_logfile, $mysql_slave_exec_position,
+      $mysql_slave_master, $mysql_slave_binlog_do_db, 
+      $mysql_slave_binlog_ignore_db);
   if ( not $Noaction ) {
     # Get slave database info 
     my $slave_status = $mysql_dbh->selectrow_hashref(q{ SHOW SLAVE STATUS });
-    if ($slave_status->{Slave_IO_State}){
-      $mysql_slave_logfile           = $slave_status->{Master_Log_File};
-      $mysql_slave_position          = $slave_status->{Read_Master_Log_Pos};
+    if ($mysql_stop_slave_io || $slave_status->{Slave_IO_State}){
       $mysql_slave_master            = $slave_status->{Master_Host};
+      $mysql_slave_read_logfile      = $slave_status->{Master_Log_File};
+      $mysql_slave_read_position     = $slave_status->{Read_Master_Log_Pos};
+      $mysql_slave_exec_logfile      = $slave_status->{Relay_Master_Log_File};
+      $mysql_slave_exec_position     = $slave_status->{Exec_Master_Log_Pos};
       $mysql_slave_binlog_do_db      = $slave_status->{Replicate_Do_DB};
       $mysql_slave_binlog_ignore_db  = $slave_status->{Replicate_Ignore_DB};
     }
@@ -521,9 +550,9 @@ sub mysql_lock {
   $mysql_dbh->do(q{ SET SQL_LOG_BIN=1 }) unless $Noaction;
 
   print "$Prog: master_log_file=\"",
-    ($mysql_slave_logfile?$mysql_slave_logfile:$mysql_logfile),
+    ($mysql_slave_read_logfile?$mysql_slave_read_logfile:$mysql_logfile),
     ",\", master_log_pos=",
-    ($mysql_slave_position?$mysql_slave_position:$mysql_position),
+    ($mysql_slave_read_position?$mysql_slave_read_position:$mysql_position),
     "\n" if $mysql_logfile and not $Quiet;
 
   if ( defined($mysql_status_file) && $mysql_logfile ) {
@@ -539,8 +568,10 @@ master_log_pos="$mysql_position"
 master_binlog_do_db="$mysql_binlog_do_db"
 master_binlog_ignore_db="$mysql_binlog_ignore_db"
 slave_master_host="$mysql_slave_master"
-slave_log_file="$mysql_slave_logfile"
-slave_log_pos="$mysql_slave_position"
+slave_read_log_file="$mysql_slave_read_logfile"
+slave_read_log_pos="$mysql_slave_read_position"
+slave_exec_log_pos_log_file="$mysql_slave_exec_logfile"
+slave_exec_log_pos="$mysql_slave_exec_position"
 slave_binlog_do_db="$mysql_slave_binlog_do_db"
 slave_binlog_ignore_db="$mysql_slave_binlog_ignore_db"
 EOM
@@ -548,16 +579,17 @@ EOM
     }
   }
 
+  # Deprecated status file format
   if ( defined($mysql_master_status_file) && $mysql_logfile ) {
     $Debug and warn "$Prog: ", scalar localtime,
       ": writing MASTER STATUS to $mysql_master_status_file\n";
     if ( not $Noaction ) {
       open(MYSQLMASTERSTATUS,"> $mysql_master_status_file") or
         die "$Prog: Unable to open for write: $mysql_master_status_file: $!\n";
-      if ( $mysql_slave_logfile) {
+      if ( $mysql_slave_read_logfile) {
         print MYSQLMASTERSTATUS <<"EOM";
-master_log_file="$mysql_slave_logfile"
-master_log_pos="$mysql_slave_position"
+master_log_file="$mysql_slave_read_logfile"
+master_log_pos="$mysql_slave_read_position"
 master_binlog_do_db="$mysql_slave_binlog_do_db"
 master_binlog_ignore_db="$mysql_slave_binlog_ignore_db"
 EOM
@@ -582,6 +614,10 @@ sub mysql_unlock {
   $Debug and warn "$Prog: ", scalar localtime, ": MySQL unlock\n";
   $mysql_dbh->do(q{ UNLOCK TABLES }) unless $Noaction;
 
+  if ( $mysql_stop_slave_io ) {
+      $Debug and warn "$Prog: ", scalar localtime, ": MySQL start slave io_thread\n";
+      $mysql_dbh->do(q{ START SLAVE IO_THREAD }) unless $Noaction
+  }
 }
 
 sub mysql_stop {
@@ -907,16 +943,30 @@ lock tables.  User must have appropriate permissions.  Defaults to
 $HOME/.my.cnf file contents.
 
 =item --mysql-master-status-file FILE
+    
+Store both the MASTER STATUS (or slave status if this server is a slave) 
+output in a file on the snapshot. It will be removed after the EBS 
+snapshot is taken. This option will be ignored with --mysql-stop
+\[DEPRECATED in favor of mysql-status-file\] 
 
-Store the MASTER STATUS output in a file on the snapshot. It will be
-removed after the EBS snapshot is taken.  This option will be ignored
-with --mysql-stop
+=item --mysql--status-file FILE
+    
+Store both MASTER STATUS and SLAVE STATUS output in a file on the snapshot. 
+It will be removed after the EBS snapshot is taken. This option will be 
+ignored with --mysql-stop. This options is a more consistent alternative
+to --mysql-master-status-file
 
 =item --mysql-stop
 
 Indicates that the volume contains data files for a running MySQL
 database.  The database is shutdown before the snapshot is initiated
 and restarted afterwards. [EXPERIMENTAL]
+
+=item --mysql-stop-slave-io
+
+Issue a "STOP SLAVE IO_THREAD" before taking snapshot to stop disk
+activity. Will also cause MySQL to flush RELAY logs for better consistency.
+[EXPERIMENTAL]
 
 =item --snapshot-timeout SECONDS
 


### PR DESCRIPTION
New option --mysql-stop-slave-io

This stops SLAVE IO THREAD on MySQL. With later FLUSH+LOCK this should
stop all MySQL disk activity before taking snapshot. Also we flush relay
log files for better consistency.

This PR also incorporates #19 regarding new status file format with some minor fixes.