### PR TITLE
Percona-only solution for FLUSH LOCAL TABLES issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,12 @@ ec2-consistent-snapshot - Create EBS snapshots on EC2 w/consistent filesystem/db
     database.  The database is shutdown before the snapshot is initiated
     and restarted afterwards. \[EXPERIMENTAL\]
 
+- \--percona
+
+    Indicates that the volume contains data files for a running Percona/MySQL
+    database, which will be locked using Percona's unique backup locking commands.
+    Note: this sets '--mysql' automatically.
+
 - \--snapshot-timeout SECONDS
 
     How many seconds to wait for the snapshot-create to return.  Defaults

--- a/ec2-consistent-snapshot
+++ b/ec2-consistent-snapshot
@@ -50,6 +50,7 @@ my $mysql_username             = undef;
 my $mysql_password             = undef;
 my $mysql_host                 = undef;
 my $mysql_stop                 = 0;
+my $percona                    = 0;
 my $snapshot_timeout           = 10.0; # seconds
 my $lock_timeout               =  0.5; # seconds
 my $lock_tries                 = 60;
@@ -91,6 +92,7 @@ GetOptions(
   'mysql-password=s'             => \$mysql_password,
   'mysql-host=s'                 => \$mysql_host,
   'mysql-stop'                   => \$mysql_stop,
+  'percona'                      => \$percona,
   'snapshot-timeout=s'           => \$snapshot_timeout,
   'lock-timeout=s'               => \$lock_timeout,
   'lock-tries=s'                 => \$lock_tries,
@@ -112,6 +114,8 @@ $ec2_endpoint ||= "https://ec2.$region.amazonaws.com" if $region;
 my $freeze_cmd = "fsfreeze";
 $freeze_cmd    = "xfs_freeze"
     if $freeze_cmd and system("which $freeze_cmd >/dev/null") != 0;
+
+$mysql = 1 if $percona; # Percona is a variant of MySQL
 
 #---- MAIN ----
 
@@ -464,25 +468,44 @@ sub mysql_lock {
   # as this can interfere with long-running queries on the slaves.
   $mysql_dbh->do(q{ SET SQL_LOG_BIN=0 }) unless $Noaction;
 
-  # Try a flush first without locking so the later flush with lock
-  # goes faster.  This may not be needed as it seems to interfere with
-  # some statements anyway.
-  sql_timeout_retry(
-    q{ FLUSH LOCAL TABLES },
-    "MySQL flush",
-    $lock_timeout,
-    $lock_tries,
-    $lock_sleep,
-  );
+  if ( $percona ) {
+    # http://www.percona.com/blog/2014/03/11/introducing-backup-locks-percona-server-2/
+    sql_timeout_retry(
+      q{ LOCK TABLES FOR BACKUP },
+      "Percona table lock",
+      $lock_timeout,
+      $lock_tries,
+      $lock_sleep,
+    );
 
-  # Get a lock on the entire database
-  sql_timeout_retry(
-    q{ FLUSH LOCAL TABLES WITH READ LOCK },
-    "MySQL flush & lock",
-    $lock_timeout,
-    $lock_tries,
-    $lock_sleep,
-  );
+    sql_timeout_retry(
+      q{ LOCK BINLOG FOR BACKUP },
+      "Percona binlog lock",
+      $lock_timeout,
+      $lock_tries,
+      $lock_sleep,
+    );
+  } else {
+    # Try a flush first without locking so the later flush with lock
+    # goes faster.  This may not be needed as it seems to interfere with
+    # some statements anyway.
+    sql_timeout_retry(
+      q{ FLUSH LOCAL TABLES },
+      "MySQL flush",
+      $lock_timeout,
+      $lock_tries,
+      $lock_sleep,
+    );
+
+    # Get a lock on the entire database
+    sql_timeout_retry(
+      q{ FLUSH LOCAL TABLES WITH READ LOCK },
+      "MySQL flush & lock",
+      $lock_timeout,
+      $lock_tries,
+      $lock_sleep,
+    );
+  }
 
   my ($mysql_logfile, $mysql_position,
       $mysql_binlog_do_db, $mysql_binlog_ignore_db);
@@ -532,7 +555,10 @@ sub mysql_unlock {
   my ($mysql_dbh) = @_;
 
   $Debug and warn "$Prog: ", scalar localtime, ": MySQL unlock\n";
-  $mysql_dbh->do(q{ UNLOCK TABLES }) unless $Noaction;
+  unless ( $Noaction ) {
+    $mysql_dbh->do(q{ UNLOCK TABLES });
+    $mysql_dbh->do(q{ UNLOCK BINLOG }) if $percona;
+  }
 
 }
 
@@ -869,6 +895,12 @@ with --mysql-stop
 Indicates that the volume contains data files for a running MySQL
 database.  The database is shutdown before the snapshot is initiated
 and restarted afterwards. [EXPERIMENTAL]
+
+=item --percona
+
+Indicates that the volume contains data files for a running Percona/MySQL
+database, which will be locked using Percona's unique backup locking commands.
+Note: this sets '--mysql' automatically.
 
 =item --snapshot-timeout SECONDS
 

--- a/ec2-consistent-snapshot
+++ b/ec2-consistent-snapshot
@@ -477,14 +477,6 @@ sub mysql_lock {
       $lock_tries,
       $lock_sleep,
     );
-
-    sql_timeout_retry(
-      q{ LOCK BINLOG FOR BACKUP },
-      "Percona binlog lock",
-      $lock_timeout,
-      $lock_tries,
-      $lock_sleep,
-    );
   } else {
     # Try a flush first without locking so the later flush with lock
     # goes faster.  This may not be needed as it seems to interfere with
@@ -555,10 +547,7 @@ sub mysql_unlock {
   my ($mysql_dbh) = @_;
 
   $Debug and warn "$Prog: ", scalar localtime, ": MySQL unlock\n";
-  unless ( $Noaction ) {
-    $mysql_dbh->do(q{ UNLOCK TABLES });
-    $mysql_dbh->do(q{ UNLOCK BINLOG }) if $percona;
-  }
+  $mysql_dbh->do(q{ UNLOCK TABLES }) unless $Noaction;
 
 }
 

--- a/ec2-consistent-snapshot
+++ b/ec2-consistent-snapshot
@@ -539,8 +539,6 @@ EOM
       close(MYSQLMASTERSTATUS);
     }
   }
-
-  return ($mysql_logfile, $mysql_position);
 }
 
 sub mysql_unlock {

--- a/ec2-consistent-snapshot
+++ b/ec2-consistent-snapshot
@@ -116,6 +116,9 @@ $freeze_cmd    = "xfs_freeze"
     if $freeze_cmd and system("which $freeze_cmd >/dev/null") != 0;
 
 $mysql = 1 if $percona; # Percona is a variant of MySQL
+die "$Prog: ERROR: The --percona and --mysql-master-status-file options are mutually exclusive. ",
+                  "Percona locking does not give accurate binlog location."
+  if $percona and defined($mysql_master_status_file);
 
 #---- MAIN ----
 
@@ -477,6 +480,10 @@ sub mysql_lock {
       $lock_tries,
       $lock_sleep,
     );
+
+    $mysql_dbh->do(q{ SET SQL_LOG_BIN=1 }) unless $Noaction;
+    return # do not store/print binlog info as can be erroneous
+
   } else {
     # Try a flush first without locking so the later flush with lock
     # goes faster.  This may not be needed as it seems to interfere with


### PR DESCRIPTION
Even though #23 and #39 seem to have dealt with the `FLUSH LOCAL TABLES` issue extensively, we were still experiencing site outages.  The query-killing timeouts from #39 do not release the global lock, so even though our long-running queries are `SELECT` only, they still cripple the site when they coincide with `FLT`.  All of the subsequent `SELECT` queries wait for the lock to be released.

> FLUSH TABLES WITH READ LOCK can be run even though there may be a running query that has been executing for hours. In this case everything will be locked up in Waiting for table flush or Waiting for master to send event states. Killing the FLUSH TABLES WITH READ LOCK does not correct this issue either. In this case the only way to get the server operating normally again is to kill off the long running queries that blocked it to begin with.

-- from http://www.percona.com/doc/percona-xtrabackup/2.1/innobackupex/improved_ftwrl.html

The solution to this situation for plain MySQL _using **InnoDB** tables only_ may well be to not attempt the FLUSH at all, but thankfully we're using Percona and the tools for dealing with this safely have already been provided for us: http://www.percona.com/blog/2014/03/11/introducing-backup-locks-percona-server-2/ (this link also contains a good history lesson and explanation of what `FLT` actually does).

As noted in the article, Percona now also provides a facility for locking the binary log to ensure it matches the state of the data at the time of backup.  We initially implemented this also, but backed it out once we realised the implications.  If, for example, this script dies part-way through and leaves the table lock on, only schema changes are prevented - not so bad at all.  But if the binary log lock is left on, no transactions can be committed, so the server is essentially left in read-only mode.

For our use case, our replication failover is the continuity mechanism and we'd only be restoring from an EC2 snapshot if the replication had failed, so we wouldn't be looking to continue immediate replication anyway.

The attached changes include a `--percona` flag to switch to the backup locking mechanism provided by Percona, but intentionally stop short of ensuring that the binary log remains consistent with the data, due to the issue above.

This version is running successfully in our production system, however Perl is not one of our strengths, so please let us know if there is anything that should change.

Thanks. :)