### PR TITLE
Make --mysql-stop not require MySQL authentication.

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,10 @@ ec2-consistent-snapshot - Create EBS snapshots on EC2 w/consistent filesystem/db
     Indicates that the volume contains data files for a running MySQL
     database, which will be flushed and locked during the snapshot.
 
+    To connect, we will first look in \`--mysql-defaults-file\`, if provided.
+    Otherwise, the values of \`--mysql-host\`, \`--mysql-socket\`, \`--mysql-username\`
+    and \`--mysql-password\` will be used to build the connection string.
+
 - --mysql-defaults-file FILE
 
     MySQL defaults file, containing host, username and password, this
@@ -137,9 +141,11 @@ ec2-consistent-snapshot - Create EBS snapshots on EC2 w/consistent filesystem/db
 
 - --mysql-stop
 
-    Indicates that the volume contains data files for a running MySQL
-    database.  The database is shutdown before the snapshot is initiated
-    and restarted afterwards. \[EXPERIMENTAL\]
+    Indicates that the volume contains data files for a running MySQL database.
+    The database is shutdown using \`/usr/bin/mysqladmin stop\` before the snapshot
+    is initiated and restarted afterwards using \`/etc/init.d/mysql start\`. Suitable
+    for running as root when a few seconds of downtime are acceptable.
+    \[EXPERIMENTAL\]
 
 - --percona
 

--- a/README.md
+++ b/README.md
@@ -144,8 +144,9 @@ ec2-consistent-snapshot - Create EBS snapshots on EC2 w/consistent filesystem/db
     Indicates that the volume contains data files for a running MySQL database.
     The database is shutdown using \`/usr/bin/mysqladmin stop\` before the snapshot
     is initiated and restarted afterwards using \`/etc/init.d/mysql start\`. Suitable
-    for running as root when a few seconds of downtime are acceptable.
-    \[EXPERIMENTAL\]
+    for running as root when a few seconds of downtime are acceptable. Authentication
+    is done using \`--mysql-defaults-file\`, which defaults to \`/etc/mysql/debian.cnf\`,
+    which handles shutdowns as root on Debian and Ubuntu.  \[EXPERIMENTAL\]
 
 - --percona
 

--- a/ec2-consistent-snapshot
+++ b/ec2-consistent-snapshot
@@ -1017,6 +1017,11 @@ and restarted afterwards. [EXPERIMENTAL]
 Indicates that the volume contains data files for a running MySQL
 database, which will be flushed and locked during the snapshot.
 
+To connect, we will first look in `--mysql-defaults-file`, if provided.
+Otherwise, the values of `--mysql-host`, `--mysql-socket`, `--mysql-username`
+and `--mysql-password` will be used to build the connection string.
+
+
 =item --mysql-defaults-file FILE
 
 MySQL defaults file, containing host, username and password, this
@@ -1043,9 +1048,11 @@ with --mysql-stop
 
 =item --mysql-stop
 
-Indicates that the volume contains data files for a running MySQL
-database.  The database is shutdown before the snapshot is initiated
-and restarted afterwards. [EXPERIMENTAL]
+Indicates that the volume contains data files for a running MySQL database.
+The database is shutdown using `/usr/bin/mysqladmin stop` before the snapshot
+is initiated and restarted afterwards using `/etc/init.d/mysql start`. Suitable
+for running as root when a few seconds of downtime are acceptable.
+[EXPERIMENTAL]
 
 =item --percona
 

--- a/ec2-consistent-snapshot
+++ b/ec2-consistent-snapshot
@@ -702,7 +702,21 @@ sub mysql_unlock {
 sub mysql_stop {
   $Debug and warn "$Prog: ", scalar localtime, ": MySQL stop\n";
 
-  my $result = system('/usr/bin/mysqladmin', 'shutdown');
+  my @args = ('/usr/bin/mysqladmin');
+
+  # If an explicit defaults-file was provided, use that.
+  if ($mysql_defaults_file) {
+    push @args,  "--defaults-file=$mysql_defaults_file";
+  }
+  # Otherwise, Debian and Ubuntu use this file to hold credentials that can be used for maintenance.
+  # If you can read the file, usually as root, it should work.
+  elsif (-r '/etc/mysql/debian.cnf') {
+    push @args, "--defaults-file=/etc/mysql/debian.cnf";
+  }
+
+  push @args, 'shutdown';
+
+  my $result = system(@args);
 
   if ( $result != 0 ) {
     die "$Prog: Unable to stop mysqld: $? $!";
@@ -1051,8 +1065,9 @@ with --mysql-stop
 Indicates that the volume contains data files for a running MySQL database.
 The database is shutdown using `/usr/bin/mysqladmin stop` before the snapshot
 is initiated and restarted afterwards using `/etc/init.d/mysql start`. Suitable
-for running as root when a few seconds of downtime are acceptable.
-[EXPERIMENTAL]
+for running as root when a few seconds of downtime are acceptable. Authentication
+is done using `--mysql-defaults-file`, which defaults to `/etc/mysql/debian.cnf`,
+which handles shutdowns as root on Debian and Ubuntu.  [EXPERIMENTAL]
 
 =item --percona
 

--- a/ec2-consistent-snapshot
+++ b/ec2-consistent-snapshot
@@ -702,6 +702,11 @@ sub mysql_unlock {
 sub mysql_stop {
   $Debug and warn "$Prog: ", scalar localtime, ": MySQL stop\n";
 
+  if ( $Noaction ) {
+    warn "mysql stop SKIPPED (--noaction)\n";
+    return undef;
+  }
+
   my @args = ('/usr/bin/mysqladmin');
 
   # If an explicit defaults-file was provided, use that.


### PR DESCRIPTION
Before the MySQL stop/start sequence was using an asymmetric approach.
"mysqladmin stop" was used to stop MySQL, while "/etc/init.d/mysql" start"
was used to start MySQL, which does not require MySQL authentication.

Running "mysqladmin stop" as root could sometimes fail due to
authentication issues:

 /usr/bin/mysqladmin: connect to server at 'localhost' failed
error: 'Access denied for user 'root'@'localhost' (using password: NO)'
ec2-consistent-snapshot: Unable to stop mysqld: 256 No such file or
directory at /usr/bin/ec2-consistent-snapshot line 727.

Using --mysql-stop already depends on "/etc/init.d/mysql" to exist and
provide a "start" command. Further, it requires that the user be able to
run that command. If all those conditions are met, it's reasonable to
assume that "/etc/init.d/mysql" also provides a "stop" command, that the
user is allowed to run it as well.