### PR TITLE
Add dependency on the MongoDB Perl library that's used.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Vcs-Git: git@github.com:alestic/ec2-consistent-snapshot.git
 
 Package: ec2-consistent-snapshot
 Architecture: all
-Depends: ${misc:Depends}, xfsprogs, perl, libnet-amazon-ec2-perl, libfile-slurp-perl, libwww-perl, libdigest-hmac-perl, libparams-validate-perl, libxml-simple-perl, libmoose-perl, libcrypt-ssleay-perl, libdatetime-locale-perl, libdatetime-timezone-perl, libdbd-mysql-perl, libio-socket-ssl-perl
+Depends: ${misc:Depends}, xfsprogs, perl, libnet-amazon-ec2-perl, libfile-slurp-perl, libwww-perl, libdigest-hmac-perl, libparams-validate-perl, libxml-simple-perl, libmoose-perl, libcrypt-ssleay-perl, libdatetime-locale-perl, libdatetime-timezone-perl, libdbd-mysql-perl, libio-socket-ssl-perl, libmongodb-perl
 Description: Initiate consistent EBS snapshots in Amazon EC2
  The "ec2-consistent-snapshot" command can be used to initiate
  EBS (elastic block volume) snapshots in Amazon EC2.  In particular,


### PR DESCRIPTION
This parallels how the dependency of the MySQL Perl driver is handled.