### PR TITLE
Add existence check for mysql_master_status_file

### DIFF
--- a/ec2-consistent-snapshot
+++ b/ec2-consistent-snapshot
@@ -194,8 +194,10 @@ END {
     $Debug and warn "$Prog: ", scalar localtime,
       ": removing master info file: $mysql_master_status_file\n";
     if ( not $Noaction ) {
-      unlink $mysql_master_status_file
-        or die "$Prog: Couldn't remove file: $mysql_master_status_file: $!\n";
+      if ( -e $mysql_master_status_file ) {
+        unlink $mysql_master_status_file
+          or die "$Prog: Couldn't remove file: $mysql_master_status_file: $!\n";
+      }
     }
   }
 


### PR DESCRIPTION
Add and existence check before unlink-ing the master_status_file. This was
causing us an issue where we retryed on failures, but had actually succeeded.
This check will make sure we do not die just because the unlink failed.