### PR TITLE
--percona: allow master-status-file option

### DIFF
--- a/ec2-consistent-snapshot
+++ b/ec2-consistent-snapshot
@@ -408,6 +408,12 @@ sub mysql_connect {
   return $mysql_dbh;
 }
 
+sub mysql_is_slave {
+  my ($mysql_dbh) = @_;
+  my $slave_status = $mysql_dbh->selectrow_hashref(q{ SHOW SLAVE STATUS });
+  return $slave_status->{Slave_SQL_Running} eq 'Yes';
+}
+
 sub mysql_lock {
   my ($mysql_dbh) = @_;
 
@@ -419,12 +425,12 @@ sub mysql_lock {
     # STOP SLAVE blocks until the current replication group is done processing
     # so we only really need to run it once with a high timeout
     sql_timeout_retry(
-      q{ STOP SLAVE},
-      "MySQL flush",
+      q{ STOP SLAVE },
+      "MySQL Stop Replication",
       $lock_timeout * $lock_tries,
       1,
       0,
-    );
+    ) unless $Noaction;
   } else {
     # Try a flush first without locking so the later flush with lock
     # goes faster.  This may not be needed as it seems to interfere with
@@ -452,9 +458,7 @@ sub mysql_lock {
   if ( not $Noaction ) {
     # This might be a slave database already
     my $slave_status = $mysql_dbh->selectrow_hashref(q{ SHOW SLAVE STATUS });
-    $mysql_logfile           = $slave_status->{Slave_IO_State}
-                             ? $slave_status->{Master_Log_File}
-                             : undef;
+    $mysql_logfile           = $slave_status->{Master_Log_File};
     $mysql_position          = $slave_status->{Read_Master_Log_Pos};
     $mysql_binlog_do_db      = $slave_status->{Replicate_Do_DB};
     $mysql_binlog_ignore_db  = $slave_status->{Replicate_Ignore_DB};
@@ -463,7 +467,7 @@ sub mysql_lock {
     ($mysql_logfile, $mysql_position,
      $mysql_binlog_do_db, $mysql_binlog_ignore_db) =
       $mysql_dbh->selectrow_array(q{  SHOW MASTER STATUS  })
-      unless $mysql_logfile;
+      unless mysql_is_slave($mysql_dbh);
   }
 
   $mysql_dbh->do(q{ SET SQL_LOG_BIN=1 }) unless $Noaction;

--- a/ec2-consistent-snapshot
+++ b/ec2-consistent-snapshot
@@ -42,6 +42,7 @@ my $mongo_host                 = undef;
 my $mongo_port                 = 27017;
 my $mongo_stop                 = 0;
 my $mysql                      = 0;
+my $mysql_stop_slave           = 0;
 #my $mysql_defaults_file        = "$ENV{HOME}/.my.cnf";
 my $mysql_defaults_file        = undef;
 my $mysql_socket               = undef;
@@ -83,6 +84,7 @@ GetOptions(
   'mongo-port=s'                 => \$mongo_port,
   'mongo-stop'                   => \$mongo_stop,
   'mysql'                        => \$mysql,
+  'mysql-stop-slave'             => \$mysql_stop_slave,
   'mysql-defaults-file=s'        => \$mysql_defaults_file,
   'mysql-socket=s'               => \$mysql_socket,
   'mysql-master-status-file=s'   => \$mysql_master_status_file,
@@ -413,25 +415,37 @@ sub mysql_lock {
   # as this can interfere with long-running queries on the slaves.
   $mysql_dbh->do(q{ SET SQL_LOG_BIN=0 }) unless $Noaction;
 
-  # Try a flush first without locking so the later flush with lock
-  # goes faster.  This may not be needed as it seems to interfere with
-  # some statements anyway.
-  sql_timeout_retry(
-    q{ FLUSH LOCAL TABLES },
-    "MySQL flush",
-    $lock_timeout,
-    $lock_tries,
-    $lock_sleep,
-  );
+  if ( $mysql_stop_slave ) {
+    # STOP SLAVE blocks until the current replication group is done processing
+    # so we only really need to run it once with a high timeout
+    sql_timeout_retry(
+      q{ STOP SLAVE},
+      "MySQL flush",
+      $lock_timeout * $lock_tries,
+      1,
+      0,
+    );
+  } else {
+    # Try a flush first without locking so the later flush with lock
+    # goes faster.  This may not be needed as it seems to interfere with
+    # some statements anyway.
+    sql_timeout_retry(
+      q{ FLUSH LOCAL TABLES },
+      "MySQL flush",
+      $lock_timeout,
+      $lock_tries,
+      $lock_sleep,
+    );
 
-  # Get a lock on the entire database
-  sql_timeout_retry(
-    q{ FLUSH LOCAL TABLES WITH READ LOCK },
-    "MySQL flush & lock",
-    $lock_timeout,
-    $lock_tries,
-    $lock_sleep,
-  );
+    # Get a lock on the entire database
+    sql_timeout_retry(
+      q{ FLUSH LOCAL TABLES WITH READ LOCK },
+      "MySQL flush & lock",
+      $lock_timeout,
+      $lock_tries,
+      $lock_sleep,
+    );
+  }
 
   my ($mysql_logfile, $mysql_position,
       $mysql_binlog_do_db, $mysql_binlog_ignore_db);
@@ -481,7 +495,11 @@ sub mysql_unlock {
   my ($mysql_dbh) = @_;
 
   $Debug and warn "$Prog: ", scalar localtime, ": MySQL unlock\n";
-  $mysql_dbh->do(q{ UNLOCK TABLES }) unless $Noaction;
+  if ( $mysql_stop_slave ) {
+     $mysql_dbh->do(q{ START SLAVE }) unless $Noaction;
+  } else {
+     $mysql_dbh->do(q{ UNLOCK TABLES }) unless $Noaction;
+  }
 
 }
 
@@ -774,6 +792,14 @@ and restarted afterwards. [EXPERIMENTAL]
 
 Indicates that the volume contains data files for a running MySQL
 database, which will be flushed and locked during the snapshot.
+
+=item --mysql-stop-slave
+
+Indicates that "STOP SLAVE" should be used instead of "FLUSH TABLES
+WITH READ LOCK" which can inadvertently lock up mysql, See :
+http://www.mysqlperformanceblog.com/2012/03/23/how-flush-tables-with-read-lock-works-with-innodb-tables/
+Note: This should only be used on mysql replication slaves as this
+doesn't prevent writes by other users during the backup.
 
 =item --mysql-defaults-file FILE
 

--- a/ec2-consistent-snapshot
+++ b/ec2-consistent-snapshot
@@ -485,20 +485,26 @@ sub mysql_lock {
   }
 
   my ($mysql_logfile, $mysql_position,
-      $mysql_binlog_do_db, $mysql_binlog_ignore_db);
+      $mysql_binlog_do_db, $mysql_binlog_ignore_db,
+      $mysql_master_hostname);
   if ( not $Noaction ) {
     # This might be a slave database already
     my $slave_status = $mysql_dbh->selectrow_hashref(q{ SHOW SLAVE STATUS });
+    $mysql_master_hostname   = $slave_status->{Master_Host};
     $mysql_logfile           = $slave_status->{Relay_Master_Log_File};
     $mysql_position          = $slave_status->{Exec_Master_Log_Pos};
     $mysql_binlog_do_db      = $slave_status->{Replicate_Do_DB};
     $mysql_binlog_ignore_db  = $slave_status->{Replicate_Ignore_DB};
 
     # or this might be the master
-    ($mysql_logfile, $mysql_position,
-     $mysql_binlog_do_db, $mysql_binlog_ignore_db) =
-      $mysql_dbh->selectrow_array(q{  SHOW MASTER STATUS  })
-      unless mysql_is_slave($mysql_dbh);
+    if ( not mysql_is_slave($mysql_dbh) ) {
+      ($mysql_logfile, $mysql_position,
+       $mysql_binlog_do_db, $mysql_binlog_ignore_db) =
+       $mysql_dbh->selectrow_array(q{  SHOW MASTER STATUS  });
+      # Get the public hostname from an ec2 api endpoint.
+      # See: http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AESDG-chapter-instancedata.html
+      $mysql_master_hostname = `curl http://169.254.169.254/latest/meta-data/public-hostname`;
+    }
   }
 
   $mysql_dbh->do(q{ SET SQL_LOG_BIN=1 }) unless $Noaction;
@@ -514,6 +520,7 @@ sub mysql_lock {
       open(MYSQLMASTERSTATUS,"> $mysql_master_status_file") or
         die "$Prog: Unable to open for write: $mysql_master_status_file: $!\n";
       print MYSQLMASTERSTATUS <<"EOM";
+master_hostname="$mysql_master_hostname"
 master_log_file="$mysql_logfile"
 master_log_pos="$mysql_position"
 master_binlog_do_db="$mysql_binlog_do_db"

--- a/ec2-consistent-snapshot
+++ b/ec2-consistent-snapshot
@@ -458,8 +458,8 @@ sub mysql_lock {
   if ( not $Noaction ) {
     # This might be a slave database already
     my $slave_status = $mysql_dbh->selectrow_hashref(q{ SHOW SLAVE STATUS });
-    $mysql_logfile           = $slave_status->{Master_Log_File};
-    $mysql_position          = $slave_status->{Read_Master_Log_Pos};
+    $mysql_logfile           = $slave_status->{Relay_Master_Log_File};
+    $mysql_position          = $slave_status->{Exec_Master_Log_Pos};
     $mysql_binlog_do_db      = $slave_status->{Replicate_Do_DB};
     $mysql_binlog_ignore_db  = $slave_status->{Replicate_Ignore_DB};
 

--- a/ec2-consistent-snapshot
+++ b/ec2-consistent-snapshot
@@ -509,11 +509,12 @@ sub mysql_lock {
 
   my ($mysql_logfile, $mysql_position,
       $mysql_binlog_do_db, $mysql_binlog_ignore_db,
-      $mysql_master_hostname);
+      $mysql_master_hostname, $mysql_master_private_hostname);
   if ( not $Noaction ) {
     # This might be a slave database already
     my $slave_status = $mysql_dbh->selectrow_hashref(q{ SHOW SLAVE STATUS });
     $mysql_master_hostname   = $slave_status->{Master_Host};
+    $mysql_master_private_hostname = $slave_status->{Master_Host};
     $mysql_logfile           = $slave_status->{Relay_Master_Log_File};
     $mysql_position          = $slave_status->{Exec_Master_Log_Pos};
     $mysql_binlog_do_db      = $slave_status->{Replicate_Do_DB};
@@ -527,6 +528,7 @@ sub mysql_lock {
       # Get the public hostname from an ec2 api endpoint.
       # See: http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AESDG-chapter-instancedata.html
       $mysql_master_hostname = `curl http://169.254.169.254/latest/meta-data/public-hostname`;
+      $mysql_master_private_hostname = `curl http://169.254.169.254/latest/meta-data/hostname`;
     }
   }
 
@@ -544,6 +546,7 @@ sub mysql_lock {
         die "$Prog: Unable to open for write: $mysql_master_status_file: $!\n";
       print MYSQLMASTERSTATUS <<"EOM";
 master_hostname="$mysql_master_hostname"
+master_private_hostname="$mysql_master_private_hostname"
 master_log_file="$mysql_logfile"
 master_log_pos="$mysql_position"
 master_binlog_do_db="$mysql_binlog_do_db"

--- a/ec2-consistent-snapshot
+++ b/ec2-consistent-snapshot
@@ -256,13 +256,16 @@ sub ebs_snapshot {
 
     my $snapshot;
     eval {
-      local $SIG{ALRM} = sub { ualarm(0); die "timeout\n" };
-      ualarm($snapshot_timeout * 1_000_000);
-      $snapshot = $ec2->create_snapshot(
-        VolumeId    => $volume_id,
-        Description => $description,
-      );
+       eval {
+         local $SIG{ALRM} = sub { ualarm(0); die "timeout\n" };
+         ualarm($snapshot_timeout * 1_000_000);
+         $snapshot = $ec2->create_snapshot(
+           VolumeId    => $volume_id,
+           Description => $description,
+         );
+      };
       ualarm(0);
+      die $@ if $@;
     };
     ualarm(0);
     if ( $@  ){
@@ -528,11 +531,13 @@ sub sql_timeout_retry {
   while ( $lock_tries -- ) {
     $Debug and warn "$Prog: ", scalar localtime, ": $description\n";
     eval {
-      ualarm($lock_timeout * 1_000_000);
-      $mysql_dbh->do($sql) unless $Noaction;
-      ualarm(0);
+       eval {
+         ualarm($lock_timeout * 1_000_000);
+         $mysql_dbh->do($sql) unless $Noaction;
+       };
+       ualarm(0);
+       die $@ if $@; 
     };
-    ualarm(0);
     last LOCK unless $@ =~ /timeout/;
 
     if ( $mysql_kill_query ) {

--- a/ec2-consistent-snapshot
+++ b/ec2-consistent-snapshot
@@ -656,7 +656,7 @@ sub mysql_lock {
     $mysql_dbh->do(q{ SET SQL_LOG_BIN=1 }) unless $Noaction;
     return # do not store/print binlog info as can be erroneous
 
-  } else if ( $mysql_stop_slave ) {
+  } elsif ( $mysql_stop_slave ) {
     # STOP SLAVE blocks until the current replication group is done processing
     # so we only really need to run it once with a high timeout
     sql_timeout_retry(

--- a/ec2-consistent-snapshot
+++ b/ec2-consistent-snapshot
@@ -124,9 +124,6 @@ $ec2_endpoint ||= "https://ec2.$region.amazonaws.com" if $region;
 my $freeze_cmd = _get_fsfreeze();
 
 $mysql = 1 if $percona; # Percona is a variant of MySQL
-die "$Prog: ERROR: The --percona and --mysql-master-status-file options are mutually exclusive. ",
-                  "Percona locking does not give accurate binlog location."
-  if $percona and defined($mysql_master_status_file);
 
 #---- MAIN ----
 
@@ -654,10 +651,6 @@ sub mysql_lock {
       $lock_tries,
       $lock_sleep,
     );
-
-    $mysql_dbh->do(q{ SET SQL_LOG_BIN=1 }) unless $Noaction;
-    return # do not store/print binlog info as can be erroneous
-
   } elsif ( $mysql_stop_slave ) {
     # STOP SLAVE blocks until the current replication group is done processing
     # so we only really need to run it once with a high timeout

--- a/ec2-consistent-snapshot
+++ b/ec2-consistent-snapshot
@@ -218,8 +218,10 @@ END {
     $Debug and warn "$Prog: ", scalar localtime,
       ": removing master info file: $mysql_master_status_file\n";
     if ( not $Noaction ) {
-      unlink $mysql_master_status_file
-        or die "$Prog: Couldn't remove file: $mysql_master_status_file: $!\n";
+      if ( -e $mysql_master_status_file ) {
+        unlink $mysql_master_status_file
+          or die "$Prog: Couldn't remove file: $mysql_master_status_file: $!\n";
+      }
     }
   }
 


### PR DESCRIPTION
As of percona 5.6.26, LTFB flushes binlog coordinates and thus
grabbing the master status info is safe.

See the release notes: https://www.percona.com/doc/percona-server/5.6/release-notes/Percona-Server-5.6.26-74.0.html#new-features
And the docs: https://www.percona.com/doc/percona-server/5.6/management/backup_locks.html#backup-safe-binlog-information