### PR TITLE
modify Net::Amazon::EC2

### DIFF
--- a/ec2-consistent-snapshot
+++ b/ec2-consistent-snapshot
@@ -14,7 +14,7 @@ use IO::Socket::SSL;
 use LWP::UserAgent qw();
 eval 'use Mozilla::CA';
 use Time::HiRes qw(ualarm usleep);
-use Net::Amazon::EC2 0.33;
+use Net::Amazon::EC2 0.29;
 use POSIX ':signal_h';
 use DateTime::Locale;
 use DateTime::TimeZone;


### PR DESCRIPTION
Lock it to 0.29

To fix error:
Net::Amazon::EC2 version 0.33 required--this is only version 0.29 at /usr/local/bin/ec2-consistent-snapshot line 17.
BEGIN failed--compilation aborted at /usr/local/bin/ec2-consistent-snapshot line 17.